### PR TITLE
Bump applicationinsights-web package to 2.5.7

### DIFF
--- a/Source/Microsoft.Teams.Apps.SubmitIdea/ClientApp/package.json
+++ b/Source/Microsoft.Teams.Apps.SubmitIdea/ClientApp/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@fluentui/react": "^7.115.4",
     "@fluentui/react-icons-northstar": "^0.49.0",
-    "@microsoft/applicationinsights-web": "2.5.5",
+    "@microsoft/applicationinsights-web": "2.5.7",
     "@microsoft/applicationinsights-react-js": "3.0.0",
     "@fluentui/react-northstar": "^0.49.0",
     "@microsoft/teams-js": "1.6.0",


### PR DESCRIPTION
Update the application insights package to be in sync with applicationinsights-react-js SDK version. As reported in application insights GitHub issue https://github.com/microsoft/ApplicationInsights-JS/issues/1346, there are 2 SDKs of applicationinsights-web gets downloaded during deployment with different version and in turn causing conflicts due to version mismatch. 

note: the fix will temporarily solve the build failure issue. It will be permanently fixed by removing the conflict dependency of applicationinsights-web from dependent components. 