### PR TITLE
Microsoft app insights react package sync

### DIFF
--- a/Source/Microsoft.Teams.Apps.SubmitIdea/ClientApp/package.json
+++ b/Source/Microsoft.Teams.Apps.SubmitIdea/ClientApp/package.json
@@ -6,7 +6,7 @@
     "@fluentui/react": "^7.115.4",
     "@fluentui/react-icons-northstar": "^0.49.0",
     "@microsoft/applicationinsights-web": "2.5.7",
-    "@microsoft/applicationinsights-react-js": "3.0.0",
+    "@microsoft/applicationinsights-react-js": "3.0.2",
     "@fluentui/react-northstar": "^0.49.0",
     "@microsoft/teams-js": "1.6.0",
     "@uifabric/icons": "7.3.47",

--- a/Source/Microsoft.Teams.Apps.SubmitIdea/ClientApp/package.json
+++ b/Source/Microsoft.Teams.Apps.SubmitIdea/ClientApp/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@fluentui/react": "^7.115.4",
     "@fluentui/react-icons-northstar": "^0.49.0",
-    "@microsoft/applicationinsights-web": "2.5.7",
+    "@microsoft/applicationinsights-web": "2.5.8",
     "@microsoft/applicationinsights-react-js": "3.0.2",
     "@fluentui/react-northstar": "^0.49.0",
     "@microsoft/teams-js": "1.6.0",


### PR DESCRIPTION
Microsoft application insights react JS package version needs to be updated to 3.0.2 in order to be in sync with applicationinsights-web npm package. Microsoft app insights team has upgraded the package to be always in sync for further releases as mentioned https://github.com/microsoft/ApplicationInsights-JS/issues/1346