### PR TITLE
Update AppInsights dependencies and fix ITelemetryPlugin error

### DIFF
--- a/Source/Microsoft.Teams.Apps.SubmitIdea/ClientApp/package.json
+++ b/Source/Microsoft.Teams.Apps.SubmitIdea/ClientApp/package.json
@@ -5,8 +5,8 @@
   "dependencies": {
     "@fluentui/react": "^7.115.4",
     "@fluentui/react-icons-northstar": "^0.49.0",
-    "@microsoft/applicationinsights-web": "2.5.7",
-    "@microsoft/applicationinsights-react-js": "3.0.0",
+    "@microsoft/applicationinsights-web": "2.5.8",
+    "@microsoft/applicationinsights-react-js": "3.0.2",
     "@fluentui/react-northstar": "^0.49.0",
     "@microsoft/teams-js": "1.6.0",
     "@uifabric/icons": "7.3.47",


### PR DESCRIPTION
I have experienced an issue while attempting to deploy the app to App Service. The client app has failed to build with
`Type 'ReactPlugin' is not assignable to type 'ITelemetryPlugin'.` error.

I suspect this has happened due to a version mismatch from different app insights packages.
`@microsoft/applicationinsights-react-js` has a dependency requirement on a `@microsoft/applicationinsights-core-js` with a caret and was resolved to `2.5.8`, while `@microsoft/applicationinsights-web` has a fixed depency to `2.5.7`. 

Syncing both libraries to the latest versions worked for me.