### PR TITLE
Updating app insights packages to latest

### DIFF
--- a/Source/Microsoft.Teams.Apps.SubmitIdea/ClientApp/package.json
+++ b/Source/Microsoft.Teams.Apps.SubmitIdea/ClientApp/package.json
@@ -5,8 +5,8 @@
   "dependencies": {
     "@fluentui/react": "^7.115.4",
     "@fluentui/react-icons-northstar": "^0.49.0",
-    "@microsoft/applicationinsights-web": "2.5.8",
-    "@microsoft/applicationinsights-react-js": "3.0.2",
+    "@microsoft/applicationinsights-web": "2.5.10",
+    "@microsoft/applicationinsights-react-js": "3.0.5",
     "@fluentui/react-northstar": "^0.49.0",
     "@microsoft/teams-js": "1.6.0",
     "@uifabric/icons": "7.3.47",


### PR DESCRIPTION
As per Microsoft AI team change log, using the latest @microsoft/applicationinsights-react version and dependent web version. The new deployments are failing with error

npm ERR! code ELIFECYCLE
  npm ERR! errno 1
  npm ERR! submitidea@1.0.0 build: `react-scripts build`
  npm ERR! Exit status 1
  npm ERR! 
  npm ERR! Failed at the submitidea@1.0.0 build script.
  npm ERR! This is probably not a problem with npm. There is likely additional logging output above.